### PR TITLE
set ro.secure to 0

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -1,1 +1,2 @@
 ro.debuggable=1
+ro.secure=0


### PR DESCRIPTION
ro.secure should be turned off, doing so enables more useful debugging features